### PR TITLE
fixing broken Jenkins URLs for older Jenkins instances

### DIFF
--- a/CIUtils.py
+++ b/CIUtils.py
@@ -83,6 +83,8 @@ def fetchJenkinsStatus(url):
 def getJenkinsJobStatus(serverUrl, jobName):
 	try:
 		jobUrl = serverUrl + '/job/Fuse/job/VSCode/job/' + jobName
+		if (serverUrl != NEW_DEVTOOLS_JENKINS):
+			jobApiUrl = serverUrl + '/job/' + jobName + '/api/json'
 		jobApiUrl = jobUrl + '/api/json'
 		jobStatus = fetchJenkinsStatus(jobApiUrl)
 		color = jobStatus['color']


### PR DESCRIPTION
Signed-off-by: Lars Heinemann <lhein.smx@gmail.com>